### PR TITLE
Dynatrace MCP Server functionality

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,6 +42,11 @@ RUN KIND_RELEASE=$(curl --silent "https://api.github.com/repos/kubernetes-sigs/k
     && curl -sSL -o /usr/local/bin/kind https://kind.sigs.k8s.io/dl/$KIND_RELEASE/kind-linux-$TARGETARCH \
     && chmod +x /usr/local/bin/kind
     
+# Install Node.js and npm (multi-architecture support)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g npm@latest \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,8 +47,8 @@
   ,
   // Add recommended secrets 
     "secrets": {
-      "DT_TENANT": {
-        "description": "eg. abc123 for live -> https://abc123.live.dynatrace.com or sprint -> https://abc123.sprint.dynatracelabs.com no apps in the URL"
+      "DT_ENVIRONMENT": {
+        "description": "URL to your Dynatrace Platform eg. https://abc123.apps.dynatrace.com or for sprint -> https://abc123.sprint.apps.dynatracelabs.com"
       },
       "DT_OPERATOR_TOKEN": {
         "description": "Dynatrace Operator Token, it will be created automatically when adding a new Cluster over the UI. It contains the following permissions: 'Create ActiveGate tokens' 'Read entities' 'Read settings' 'Write settings' 'Access probrem and event feed, metrics and topology' 'PaaS Integration - installer download'"

--- a/.devcontainer/makefile.sh
+++ b/.devcontainer/makefile.sh
@@ -8,14 +8,14 @@ ENV_FILE=runlocal/.env
 NAMESPACE="shinojosa"
 IMAGENAME="dt-enablement"
 REPOSITORY=$NAMESPACE/$IMAGENAME
-TAG="v1.1"
+TAG="v1.2"
 
 REPOTAG=$REPOSITORY:$TAG
 
 # Calculates the RepositoryName from the base path needed for setting the directory so the framework can load inside the container.
 getRepositoryName
 
-# Loads variables k=v from the .env file into DOCKER_ENVS such as DT_TENANT, so they can be added as environment variables to the Docker container.
+# Loads variables k=v from the .env file into DOCKER_ENVS such as DT_ENVIRONMENT, so they can be added as environment variables to the Docker container.
 getDockerEnvsFromEnvFile
 
 # Commands to be executed in the container after it is created (as in VSCode devcontainer.json)

--- a/.devcontainer/runlocal/README.md
+++ b/.devcontainer/runlocal/README.md
@@ -23,8 +23,8 @@ All variables will be read and will be passed on dynamically as environment vari
 ```sh
 # Mapping of the Secrets defined in the .devcontainer.json file
 # Dynatrace Tenant
-DT_TENANT=https://abc123.live.dynatrace.com 
-#Description: eg. abc123 for live -> https://abc123.live.dynatrace.com or sprint -> https://abc123.sprint.dynatracelabs.com no apps in the URL
+DT_ENVIRONMENT=https://abc123.apps.dynatrace.com 
+"description": "URL to your Dynatrace Platform eg. https://abc123.apps.dynatrace.com or for sprint -> https://abc123.sprint.apps.dynatracelabs.com"
 
 # Dynatrace Operator Token
 DT_OPERATOR_TOKEN=dt0c01.XXXZZZZAAAA.XXXZZZZAAAA

--- a/.devcontainer/runlocal/helper.sh
+++ b/.devcontainer/runlocal/helper.sh
@@ -13,8 +13,9 @@ getRepositoryName() {
 getDockerEnvsFromEnvFile() {
   if [[ ! -f "$ENV_FILE" ]]; then
     echo "Error: .env file not found at $ENV_FILE, before running locally read \
-the '.devcontainer/runlocal/README' file and make sure you have all the secrets \
-needed for this devcontainer to run successfully inside the .env file "
+'https://dynatrace-wwse.github.io/codespaces-framework/instantiation-types/#2-running-in-vs-code-dev-containers-or-local-container' \
+ and make sure you have all the secrets. \
+ if you don't need any, just create an empty .env file "
     exit 1
   fi
 

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -76,6 +76,7 @@ postCodespaceTracker(){
   \"codespace.type\": \"$INSTANTIATION_TYPE\",
   \"codespace.arch\": \"$ARCH\",
   \"codespace.name\": \"$CODESPACE_NAME\",
+  \"environment\": \"$DT_ENVIRONMENT\",
   \"tenant\": \"$DT_TENANT\"
   }"
 }
@@ -303,8 +304,108 @@ setUpTerminal(){
   bindFunctionsInShell
 
   setupAliases
+
+  setupMCPServer
 }
 
+setupMCPServer(){
+
+  printInfoSection "Setting up the Dynatrace 🧠 MCP Server for VS Code"
+
+  local environment=false
+  local platform=false
+  local grail_budget=false
+  local telemetry=false
+  
+  # Check if .devcontainer/runlocal/.env file exists, if not then create it
+  if [ ! -f "$ENV_FILE" ]; then
+    printInfo ".env file not found. Creating it..."
+
+    touch "$ENV_FILE"
+    
+    # Add properties
+    setEnvironmentInEnv
+    setGrailBudget
+    setTelemetry
+  else
+    printInfo ".env file already exists."
+    while IFS= read -r line || [ -n "$line" ]; do
+      # Skip empty lines and comments
+      if [[ -z "$line" || "$line" =~ ^# ]]; then
+        continue
+      fi
+
+      # Split the line into key and value
+      IFS='=' read -r key value <<< "$line"
+      # Print or process the key-value pair
+      
+      if [ "$key" = "DT_ENVIRONMENT" ]; then
+          printInfo "DT_ENVIRONMENT is set to $value"
+          environment=true
+      fi
+      if [ "$key" = "DT_PLATFORM_TOKEN" ]; then
+          printInfo "DT_PLATFORM_TOKEN set"
+          platform=true
+      fi
+      if [ "$key" = "DT_GRAIL_QUERY_BUDGET_GB" ]; then
+          printInfo "DT_GRAIL_QUERY_BUDGET_GB set to $value"
+          grail_budget=true
+      fi
+      if [ "$key" = "DT_MCP_DISABLE_TELEMETRY" ]; then
+          printInfo "DT_MCP_DISABLE_TELEMETRY set to $value"
+          telemetry=true
+      fi
+
+    done < "$ENV_FILE"
+
+    if [ $environment = false ]; then
+      setEnvironmentInEnv
+    fi
+    if [ $platform = false ]; then
+      setPlatformToken
+    fi
+    if [ $grail_budget = false ]; then
+      setGrailBudget
+    fi
+    if [ $telemetry = false ]; then
+      setTelemetry
+    fi
+  fi
+  printInfo "Settings location: $ENV_FILE"
+}
+
+setGrailBudget(){
+  printInfo "Setting DT_GRAIL_QUERY_BUDGET_GB to $DT_GRAIL_QUERY_BUDGET_GB"
+  echo -e "DT_GRAIL_QUERY_BUDGET_GB=$DT_GRAIL_QUERY_BUDGET_GB" >> "$ENV_FILE"
+}
+setTelemetry(){
+  printInfo "Setting DT_MCP_DISABLE_TELEMETRY to $DT_MCP_DISABLE_TELEMETRY"
+  echo -e "DT_MCP_DISABLE_TELEMETRY=$DT_MCP_DISABLE_TELEMETRY" >> "$ENV_FILE"
+}
+
+setPlatformToken(){
+  if [ "$#" -eq 1 ]; then
+    printInfo "Setting DT_PLATFORM_TOKEN"
+    echo -e "DT_PLATFORM_TOKEN=$1" >> "$ENV_FILE"
+  else
+    if [ -z "${DT_PLATFORM_TOKEN}" ]; then
+      printWarn "DT_PLATFORM_TOKEN is missing as environment variable"
+      printInfo "you can set it by typing in the Terminal 'setPlatformToken <token value as argument>'"
+    else
+      printInfo "DT_PLATFORM_TOKEN found as environment variable and writing to file"
+      echo -e "DT_PLATFORM_TOKEN=$DT_PLATFORM_TOKEN" >> "$ENV_FILE"
+    fi
+  fi
+}
+
+setEnvironmentInEnv(){
+  if [ -z "${DT_ENVIRONMENT}" ]; then
+    printWarn "DT_ENVIRONMENT is missing as environment variable"
+  else
+    printInfo "DT_ENVIRONMENT found as environment variable and writing to file"
+    echo -e "DT_ENVIRONMENT=$DT_ENVIRONMENT" >> "$ENV_FILE"
+  fi
+}
 
 bindFunctionsInShell() {
   printInfo "Binding functions.sh and adding a Greeting in the .zshrc for user $USER "
@@ -345,6 +446,7 @@ alias pg='ps -aux | grep'
 }
 
 installRunme() {
+  printInfoSection "Installing Runme"
   mkdir runme_binary
   if [[ "$ARCH" == "x86_64" ]]; then
     printInfoSection "Installing Runme Version $RUNME_CLI_VERSION for AMD/x86"
@@ -477,11 +579,13 @@ certmanagerEnable() {
 }
 
 validateSaveCredentials() {
+  #TODO: Refactor to evaluate variables with an indirect expansion (var name and value)
   if [[ $# -eq 3 ]]; then
     printInfo "Validating and saving Secrets DT_TENANT DT_OPERATOR_TOKEN DT_INGEST_TOKEN"
     DT_TENANT=$1
     DT_OPERATOR_TOKEN=$2
     DT_INGEST_TOKEN=$3
+    #TODO: Fix this when refactoring, only printing out when return == 0 but not 1.
     verifyParseSecret $DT_TENANT true; [ $? -eq 1 ] && verifyParseSecret $DT_TENANT false || DT_TENANT=$(verifyParseSecret $DT_TENANT false)
     verifyParseSecret $DT_OPERATOR_TOKEN true; [ $? -eq 1 ] && verifyParseSecret $DT_OPERATOR_TOKEN false || DT_OPERATOR_TOKEN=$(verifyParseSecret $DT_OPERATOR_TOKEN false)
     verifyParseSecret $DT_INGEST_TOKEN true; [ $? -eq 1 ] && verifyParseSecret $DT_INGEST_TOKEN false || DT_INGEST_TOKEN=$(verifyParseSecret $DT_INGEST_TOKEN false)
@@ -490,10 +594,12 @@ validateSaveCredentials() {
     kubectl delete configmap -n default dtcredentials 2>/dev/null
 
     kubectl create configmap -n default dtcredentials \
+      --from-literal=environment=${DT_ENVIRONMENT} \
       --from-literal=tenant=${DT_TENANT} \
       --from-literal=apiToken=${DT_OPERATOR_TOKEN} \
       --from-literal=dataIngestToken=${DT_INGEST_TOKEN}
     # Exporting clean values
+    export DT_ENVIRONMENT=$DT_ENVIRONMENT
     export DT_TENANT=$DT_TENANT
     export DT_OPERATOR_TOKEN=$DT_OPERATOR_TOKEN
     export DT_INGEST_TOKEN=$DT_INGEST_TOKEN
@@ -501,7 +607,7 @@ validateSaveCredentials() {
     export DT_OTEL_ENDPOINT=$DT_OTEL_ENDPOINT
     return 0
   else
-    printError "validateSaveCredentials function should be used like saveCredentials DT_TENANT DT_OPERATOR_TOKEN DT_INGEST_TOKEN"
+    printError "validateSaveCredentials function should be used like saveCredentials DT_ENVIRONMENT DT_OPERATOR_TOKEN DT_INGEST_TOKEN"
     return 1
   fi
 }
@@ -534,13 +640,13 @@ verifyParseSecret(){
       
       # Parse Production tenants
       if echo "$secret" | grep -q "\.apps\.dynatrace\.com"; then
-        printWarn "Production tenant invalid for API requests: changing apps for live" $print_log
+        printInfo "Production environment changing apps for live for API request" $print_log
         secret=$(echo "$secret" | sed 's/\.apps\.dynatrace\.com.*$/\.live.dynatrace\.com/g')
       fi
       
       # Parse for Sprint & DEV tenants
       if echo "$secret" | grep -q "\.apps\.dynatracelabs\.com"; then
-        printWarn "Sprint tenant invalid for API requests: removing apps" $print_log
+        printWarn "Sprint environment removing apps for API requests" $print_log
         secret=$(echo "$secret" | sed 's/\.apps\.dynatracelabs\.com.*$/\.dynatracelabs\.com/g')
       fi
       # remove anything after .com
@@ -561,7 +667,7 @@ verifyParseSecret(){
       return 0
     else
       printError "Invalid secret, this is not a valid dynatrace tenant nor dynatrace token, please verify this: $secret" $print_log
-    return 1
+      return 1
     fi
   fi
 
@@ -578,44 +684,63 @@ dynatraceEvalReadSaveCredentials() {
   local found=1
 
   if [[ $# -eq 3 ]]; then
-    DT_TENANT=$1
+    DT_ENVIRONMENT=$1
     DT_OPERATOR_TOKEN=$2
     DT_INGEST_TOKEN=$3
     # Passed as argument
+    # We shuffle environment to tenant to modify tenant for API usage
+    DT_TENANT=$DT_ENVIRONMENT
     printInfo "Secrets passed as arguments"
-    validateSaveCredentials $DT_TENANT $DT_OPERATOR_TOKEN $DT_INGEST_TOKEN
+    validateSaveCredentials "$DT_TENANT" "$DT_OPERATOR_TOKEN" "$DT_INGEST_TOKEN"
     found=0
 
-  elif [[ -n "${DT_TENANT}" && -n "${DT_OPERATOR_TOKEN}" && -n "${DT_INGEST_TOKEN}" ]]; then
+  elif [[ -n "${DT_ENVIRONMENT}" && -n "${DT_OPERATOR_TOKEN}" && -n "${DT_INGEST_TOKEN}" ]]; then
     # Found in env 
     printInfo "Secrets found in environment variables"
-    validateSaveCredentials $DT_TENANT $DT_OPERATOR_TOKEN $DT_INGEST_TOKEN
+
+    # We shuffle environment to tenant to modify tenant for API usage
+    DT_TENANT=$DT_ENVIRONMENT
+    validateSaveCredentials "$DT_TENANT" "$DT_OPERATOR_TOKEN" "$DT_INGEST_TOKEN"
     found=0
-  elif [[ -n "${DT_TENANT}" && -z "${DT_OPERATOR_TOKEN}" && -z "${DT_INGEST_TOKEN}" ]]; then
-    printWarn "Dynatrace Tenant defined but tokens are missing"
-    validateSaveCredentials $DT_TENANT $DT_OPERATOR_TOKEN $DT_INGEST_TOKEN
+  elif [[ -n "${DT_ENVIRONMENT}" ]]; then
+    printWarn "Dynatrace Environment defined but tokens are missing"
+
+    if [ -z "$DT_OPERATOR_TOKEN" ]; then
+      printWarn "DT_OPERATOR_TOKEN is missing"
+    fi
+    
+    if [ -z "$DT_INGEST_TOKEN" ]; then
+      printWarn "DT_INGEST_TOKEN is missing"
+    fi
+    
+    # We shuffle environment to tenant to modify tenant for API usage
+    DT_TENANT=$DT_ENVIRONMENT
+    validateSaveCredentials "$DT_TENANT" "$DT_OPERATOR_TOKEN" "$DT_INGEST_TOKEN"
     found=0
   else
-    printWarn "Dynatrace secrets not found as arguments nor env vars, reading from config map"
+    printWarn "Dynatrace secrets not found as arguments nor env vars, trying to fetch from config map"
     kubectl get configmap -n default dtcredentials 2>/dev/null
-    # Getting the data size
-    data=$(kubectl get configmap -n default dtcredentials | awk '{print $2}')
-    # parsing to number
-    size=$(echo $data | grep -o '[0-9]*')
-    printInfo "The Configmap has $size variables stored"
     if [[ $? -eq 0 ]]; then
+      printInfo "ConfigMap found, reading from it"
+      # Getting the data size
+      data=$(kubectl get configmap -n default dtcredentials | awk '{print $2}')
+      # parsing to number
+      size=$(echo $data | grep -o '[0-9]*')
+      printInfo "The Configmap has $size variables stored"
+      DT_ENVIRONMENT=$(kubectl get configmap -n default dtcredentials -ojsonpath={.data.environment})
       DT_TENANT=$(kubectl get configmap -n default dtcredentials -ojsonpath={.data.tenant})
       DT_OPERATOR_TOKEN=$(kubectl get configmap -n default dtcredentials -ojsonpath={.data.apiToken})
       DT_INGEST_TOKEN=$(kubectl get configmap -n default dtcredentials -ojsonpath={.data.dataIngestToken})
       found=0
     else
         printInfo "ConfigMap not found, resetting variables"
-        unset DT_TENANT DT_OPERATOR_TOKEN DT_INGEST_TOKEN
+        unset DT_ENVIRONMENT DT_TENANT DT_OPERATOR_TOKEN DT_INGEST_TOKEN
     fi
   fi
 
   if [[ $found -eq 0 ]]; then
 
+    export DT_ENVIRONMENT=$DT_ENVIRONMENT
     export DT_TENANT=$DT_TENANT
     export DT_OPERATOR_TOKEN=$DT_OPERATOR_TOKEN
     export DT_INGEST_TOKEN=$DT_INGEST_TOKEN
@@ -626,7 +751,7 @@ dynatraceEvalReadSaveCredentials() {
   else 
     printError "No Dynatrace secrets have been found in the environment and are needed for Dynatrace components."
     unset DT_EVAL_SECRETS
-    exit 1
+    return 1
   fi
 
   return $found
@@ -634,17 +759,20 @@ dynatraceEvalReadSaveCredentials() {
 
 printSecrets(){
     # Print all known vars
-    printInfo "Dynatrace Tenant: $DT_TENANT"
+    printInfo "Dynatrace Environment: $DT_ENVIRONMENT"
+    printInfo "Dynatrace Tenant (for API): $DT_TENANT"
     printInfo "Dynatrace API & PaaS Token: ${DT_OPERATOR_TOKEN:0:14}xxx..."
     printInfo "Dynatrace Ingest Token: ${DT_INGEST_TOKEN:0:14}xxx..."
     printInfo "Dynatrace Otel API Token: ${DT_INGEST_TOKEN:0:14}xxx..."
     printInfo "Dynatrace Otel Endpoint: $DT_OTEL_ENDPOINT"
+    printInfo "Secrets stored as configmap, type 'kubectl get configmap -n default dtcredentials -o json' to see them."
+
 }
 
 deployCloudNative() {
   dynatraceEvalReadSaveCredentials "$@"
 
-  printInfoSection "Deploying Dynatrace in CloudNativeFullStack mode for $DT_TENANT"
+  printInfoSection "Deploying Dynatrace in CloudNativeFullStack mode for $DT_ENVIRONMENT"
   if [ -n "${DT_TENANT}" ]; then
     # Check if the Webhook has been created and is ready
     kubectl -n dynatrace wait pod --for=condition=ready --selector=app.kubernetes.io/name=dynatrace-operator,app.kubernetes.io/component=webhook --timeout=300s
@@ -666,10 +794,10 @@ deployApplicationMonitoring() {
 
   dynatraceEvalReadSaveCredentials "$@"
 
-  printInfoSection "Deploying Dynatrace in ApplicationMonitoring mode for $DT_TENANT"
+  printInfoSection "Deploying Dynatrace in ApplicationMonitoring mode for $DT_ENVIRONMENT"
   if [ -n "${DT_TENANT}" ]; then
     # Check if the Webhook has been created and is ready
-    kubectl -n dynatrace wait pod --for=condition=ready --selector=app.kubernetes.io/name=dynatrace-operator,app.kubernetes.io/component=webhook --timeout=300s
+    kubectl -n dynatrace wait pod --for=condition=ready --selector=app.kubernetes.io/name=dynatra@ce-operator,app.kubernetes.io/component=webhook --timeout=300s
 
     kubectl -n dynatrace apply -f $REPO_PATH/.devcontainer/yaml/gen/dynakube-apponly.yaml
     
@@ -709,6 +837,7 @@ dynatraceDeployOperator() {
   printInfoSection "Deploying Dynatrace Operator"
   # posssibility to load functions.sh and call dynatraceDeployOperator A B C to save credentials and override
   # or just run in normal deployment
+  #TODO: Evaluate also Tokens and not deploy if not found.
   dynatraceEvalReadSaveCredentials "$@"
   # new lines, needed for workflow-k8s-playground, cluster in dt needs to have the name k8s-playground-{requestuser} to be able to spin up multiple instances per tenant
 
@@ -742,7 +871,7 @@ generateDynakube(){
     ARM=false
 
     if [[ "$ARCH" == "x86_64" ]]; then
-      printInfo "Codespace is running in AMD (x86_64), Dynakube image is set as default to pull the latest from the tenant $DT_TENANT"
+      printInfo "Codespace is running in AMD (x86_64), Dynakube image is set as default to pull the latest from the environment $DT_ENVIRONMENT"
     elif [[ "$ARCH" == *"arm"* || "$ARCH" == *"aarch64"* ]]; then
       printWarn "Codespace is running in ARM architecture ($ARCH), Dynakube image will be set in Dynakube for AG and OneAgent."
       printWarn "ActiveGate image: $AG_IMAGE"
@@ -827,9 +956,9 @@ undeployOperatorViaHelm(){
 
 
 installMkdocs(){
-  printInfoSection "Installing Mkdocs"
+  
   installRunme
-  printInfo "Installing MKdocs requirements"
+  printInfo "Installing MKdocs"
   pip install --break-system-packages -r docs/requirements/requirements-mkdocs.txt
   exposeMkdocs
 }
@@ -1054,7 +1183,6 @@ deployBugZapperApp(){
     return 1
   fi
 
-
   kubectl create ns bugzapper
 
   # Create deployment of todoApp
@@ -1154,6 +1282,56 @@ deployHipsterShop() {
   
 }
 
+deployUnguard(){
+
+  printInfoSection "Deploying Unguard"
+  getNextFreeAppPort true
+  PORT=$(getNextFreeAppPort)
+  if [[ $? -ne 0 ]]; then
+    printWarn "Application can't be deployed, all NodePorts are busy"
+    return 1
+  fi
+
+  if [[ "$ARCH" != "x86_64" ]]; then
+    printWarn "This version of the Unguard only supports AMD/x86 architectures and not ARM, exiting deployment..."
+    return 1
+  fi
+
+  printInfo "Unguard repository https://github.com/dynatrace-oss/unguard/"
+
+  printInfo "Adding bitnami chart ..."
+  helm repo add bitnami https://charts.bitnami.com/bitnami
+
+  printInfo "Installing unguard-mariadb ..."
+  #helm install unguard-mariadb bitnami/mariadb --version 12.0.2 --set primary.persistence.enabled=false --wait --namespace unguard --create-namespace
+
+  helm install unguard-mariadb bitnami/mariadb \
+  --version 11.5.7 \
+  --set primary.persistence.enabled=false \
+  --set image.repository=bitnamilegacy/mariadb \
+  --namespace unguard --create-namespace
+
+  printInfo "waiting for mariadb to come online..."
+
+  waitForAllReadyPods unguard
+
+  printInfo "Installing Unguard"
+  helm install unguard  oci://ghcr.io/dynatrace-oss/unguard/chart/unguard --version 0.12.0 --namespace unguard 
+
+  kubectl patch service unguard-envoy-proxy --namespace=unguard --patch="{\"spec\": {\"type\": \"NodePort\", \"ports\": [{\"port\": 8080, \"nodePort\": $PORT }]}}"
+
+
+}
+
+undeployUnguard() {
+
+  printInfoSection "Undeploying Unguard"
+  helm uninstall unguard -n unguard
+  helm uninstall unguard-mariadb -n unguard
+  kubectl delete ns unguard --force
+}
+
+
 deployApp(){
   
   if [ "$#" -eq 0 ]; then
@@ -1232,6 +1410,15 @@ deployApp(){
       fi
       ;;
 
+    7 | g | unguard)
+       if [[ $delete ]]; then
+        printInfo "Undeploying unguard..."
+        undeployUnguard
+      else
+        deployUnguard
+      fi
+      ;;
+
     *)
       printWarn "Invalid selection: '$input'. Please choose a valid app identifier."
       showDeployAppUsage
@@ -1257,6 +1444,7 @@ showDeployAppUsage(){
   printInfo "[4]   d   easytrade             +       -                                   "
   printInfo "[5]   e   hipstershop           +       -                                   "
   printInfo "[6]   f   todoapp               +       +                                   "
+  printInfo "[7]   g   unguard               +       -                                   "
   printInfo "----------------------------------------------------------------------------"
 }
 
@@ -1320,8 +1508,8 @@ verifyCodespaceCreation(){
 
 calculateTime(){
   # Read from file
-  if [ -e "$ENV_FILE" ]; then
-    source $ENV_FILE
+  if [ -e "$COUNT_FILE" ]; then
+    source $COUNT_FILE
   fi
   # if equal 0 then set duration and update file
   if [ "$DURATION" -eq 0 ]; then 
@@ -1339,14 +1527,14 @@ updateEnvVariable(){
     #printInfo "update [$variable:${(P)variable}]"
     # indirect variable expansion in ZSH
     # shellcheck disable=SC2296
-    sed "s|^$variable=.*|$variable=${(P)variable}|" $ENV_FILE > $ENV_FILE.tmp
-    mv $ENV_FILE.tmp $ENV_FILE
+    sed "s|^$variable=.*|$variable=${(P)variable}|" $COUNT_FILE > $COUNT_FILE.tmp
+    mv $COUNT_FILE.tmp $COUNT_FILE
   else
     #printInfo "BASH"
     #printInfo "update [$variable:${!variable}]"
     # indirect variable expansion in BASH
-    sed "s|^$variable=.*|$variable=${!variable}|" $ENV_FILE  > $ENV_FILE.tmp
-    mv $ENV_FILE.tmp $ENV_FILE
+    sed "s|^$variable=.*|$variable=${!variable}|" $COUNT_FILE  > $COUNT_FILE.tmp
+    mv $COUNT_FILE.tmp $COUNT_FILE
   fi
   
   export $variable
@@ -1419,6 +1607,8 @@ checkHost(){
   make_available=false
   docker_available=false
   docker_accessible=false
+  node_available=false
+  npm_available=false
 
   # Check if host is Ubuntu
   if grep -qi ubuntu /etc/os-release; then
@@ -1429,7 +1619,7 @@ checkHost(){
 
   # Check if make is installed
   if command -v make >/dev/null; then
-    printInfo "✅ make is installed"
+    printInfo "✅ make is installed (version: $(make --version))"
     make_available=true
   else
     printWarn "❌ make is NOT installed"
@@ -1438,7 +1628,7 @@ checkHost(){
 
   # Check if docker is installed
   if command -v docker >/dev/null; then
-    printInfo "✅ docker is installed"
+    printInfo "✅ docker is installed (version: $(docker --version))"
     docker_available=true
   else
     printWarn "❌ docker is NOT installed"
@@ -1454,8 +1644,26 @@ checkHost(){
     docker_accessible=false
   fi
 
+  # Check if node is installed
+  if command -v node >/dev/null; then
+    printInfo "✅ node is installed (version: $(node --version))"
+    node_available=true
+  else
+    printWarn "❌ node is NOT installed (needed for Dynatrace MCP Server)"
+    node_available=false
+  fi
+
+  # Check if npm is installed
+  if command -v npm >/dev/null; then
+    printInfo "✅ npm is installed (version: $(npm --version)) "
+    npm_available=true
+  else
+    printWarn "❌ npm is NOT installed (needed for MCP Server)"
+    npm_available=false
+  fi
+
   # Prompt if any requirement is missing
-  if [ "$make_available" = false ] || [ "$docker_available" = false ] || [ "$docker_accessible" = false ]; then
+  if [ "$make_available" = false ] || [ "$docker_available" = false ] || [ "$docker_accessible" = false ] || [ "$node_available" = false ] || [ "$npm_available" = false ]; then
     printWarn "One or more requirements are missing or not accessible"
     printWarn "Would you like to attempt to correct them now? (y/n) 'yes' to run the commands for you, 'n' we only print how to resolve the issue"
     read -r answer
@@ -1478,6 +1686,17 @@ checkHost(){
         sudo systemctl restart docker
         printWarn "You may need to log out and log back in for group changes to take effect."
       fi
+      # Install node if missing
+      if [ "$node_available" = false ]; then
+        printInfo "Installing nodejs..."
+        curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash - \
+          && sudo apt-get install -y nodejs 
+      fi
+      # Install npm if missing
+      if [ "$npm_available" = false ]; then
+        printInfo "Installing npm..."
+        sudo npm install -g npm@latest  && sudo rm -rf /var/lib/apt/lists/*
+      fi
       printInfo "Auto-fix attempted. Please re-run this function or open a new shell."
     else
       printWarn "Host setup not corrected. Some features may not work as expected."
@@ -1490,9 +1709,15 @@ checkHost(){
       if [ "$docker_accessible" = false ]; then
         printInfo "To enable Docker access: sudo usermod -aG docker $USER && sudo systemctl restart docker (then log out and back in)"
       fi
+      if [ "$node_available" = false ]; then
+        printInfo "To install nodejs: sudo apt-get update && sudo apt-get install -y nodejs"
+      fi
+      if [ "$npm_available" = false ]; then
+        printInfo "To install npm: sudo apt-get update && sudo apt-get install -y npm"
+      fi
     fi
   else
-    printInfo "✅ All requirements are met, navigate to the .devcontainer/ folder then 'make start' to start your enablement jouney 🚀"
+    printInfo "✅ All requirements are met for running the enablement-framework. Navigate to the .devcontainer/ folder then 'make start' to start your enablement jouney 🚀"
   fi
 
 }

--- a/.devcontainer/util/greeting.sh
+++ b/.devcontainer/util/greeting.sh
@@ -44,10 +44,11 @@ printCodespacesInformation(){
     echo -e " ${LILA}GitHub Pages: ${RESET}https://dynatrace-wwse.github.io/${RepositoryName}    "
     echo -e " ${LILA}GitHub Repository: ${RESET}${GITHUB_REPOSITORY}     "
     
-    if [[ -z $DT_TENANT ]]; then
-        echo -e " ${YELLOW}${WARNING}${ORANGE} No Dynatrace Tenant information provided."
+    if [[ -z $DT_ENVIRONMENT ]]; then
+        echo -e " ${YELLOW}${WARNING}${ORANGE} No Dynatrace information provided."
     else
-        echo -e " ${LILA}Dynatrace Tenant: ${RESET}${DT_TENANT}"
+        echo -e " ${LILA}Dynatrace Environment: ${RESET}${DT_ENVIRONMENT}"
+        echo -e " ${LILA}Dynatrace Environment: ${RESET}${DT_ENVIRONMENT}"
     fi
     
     echo -e "                                                                                                             "
@@ -57,6 +58,7 @@ printCodespacesInformation(){
     if [[ $CODESPACES == true ]]; then
         echo -e "Codespaces name ${RESET}${CODESPACE_NAME}${NORMAL} running for gh-user ${RESET}${PRINT_USER}    "
     fi
+    echo -e " 🧠 Dynatrace MCP Server: ${RESET}installed"
 }
 
 
@@ -103,7 +105,7 @@ printApplications(){
 
 printCodespacesVerification(){
     echo -e "${CYAN}This container has the following tools installed and configured for your best experience:${RESET} "
-    echo -e "  ${RESET}k9s kubectl helm node jq python3 gh zsh kind p10k ${RESET} "
+    echo -e "  ${RESET}k9s kubectl helm node npm jq python3 gh zsh kind p10k ${RESET} "
     echo -e "                                                                                                             "
     echo -e "${CYAN}If you want to make the endpoints public accesible, just go to the ports section in VsCode, right click on them and change the visibility to public ${NORMAL}"
     echo -e "${CYAN}When you are finished with your codespace, you can comfortably delete it by typing in the Terminal${RESET} deleteCodespace"

--- a/.devcontainer/util/greeting.sh
+++ b/.devcontainer/util/greeting.sh
@@ -48,7 +48,6 @@ printCodespacesInformation(){
         echo -e " ${YELLOW}${WARNING}${ORANGE} No Dynatrace information provided."
     else
         echo -e " ${LILA}Dynatrace Environment: ${RESET}${DT_ENVIRONMENT}"
-        echo -e " ${LILA}Dynatrace Environment: ${RESET}${DT_ENVIRONMENT}"
     fi
     
     echo -e "                                                                                                             "

--- a/.devcontainer/util/variables.sh
+++ b/.devcontainer/util/variables.sh
@@ -14,6 +14,13 @@ export AG_IMAGE=$AG_IMAGE
 OA_IMAGE="public.ecr.aws/dynatrace/dynatrace-oneagent:1.319.68.20250813-080958"
 export OA_IMAGE=$OA_IMAGE
 
+#MCP Server Settings
+DT_GRAIL_QUERY_BUDGET_GB=1000
+export DT_GRAIL_QUERY_BUDGET_GB=$DT_GRAIL_QUERY_BUDGET_GB
+
+DT_MCP_DISABLE_TELEMETRY=false
+export DT_MCP_DISABLE_TELEMETRY=$DT_MCP_DISABLE_TELEMETRY
+
 ENDPOINT_CODESPACES_TRACKER=https://codespaces-tracker.whydevslovedynatrace.com/api/receive
 CODESPACES_TRACKER_TOKEN_STRING="ilovedynatrace"
 
@@ -37,7 +44,13 @@ export NODE_PORTS="$PORTS_STRING"
 CODESPACE_PSHARE_FOLDER="/workspaces/.codespaces/.persistedshare"
 
 # Dynamic Variables between phases
-ENV_FILE="$REPO_PATH/.devcontainer/util/.env"
+COUNT_FILE="$REPO_PATH/.devcontainer/util/.count"
+export COUNT_FILE=$COUNT_FILE
+
+# Env file (needed for MCP and local runs)
+ENV_FILE="$REPO_PATH/.devcontainer/runlocal/.env"
+export ENV_FILE=$ENV_FILE
+
 
 # Calculating GH Repository
 if [ -z "$GITHUB_REPOSITORY" ]; then
@@ -57,13 +70,13 @@ else
 fi
 export INSTANTIATION_TYPE=$INSTANTIATION_TYPE
 
-if [ -e "$ENV_FILE" ]; then
+if [ -e "$COUNT_FILE" ]; then
   # file exists
-  source $ENV_FILE
+  source $COUNT_FILE
 else
   # create .env file and add variables
-  echo -e "DURATION=0\nERROR_COUNT=0" > $ENV_FILE
-  source $ENV_FILE
+  echo -e "DURATION=0\nERROR_COUNT=0" > $COUNT_FILE
+  source $COUNT_FILE
 fi
 
 # Calculating architecture

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,5 +1,5 @@
 name: integration-tests
-run-name: ${{ github.event.head_commit.message }} - integration test
+run-name: ${{ github.event.head_commit.message }} - PR integration test
 permissions:
   contents: write
 on:
@@ -12,7 +12,7 @@ jobs:
     # No CI Test should run longer than 10 minutes.
     timeout-minutes: 10
     env:
-      DT_TENANT: ${{ secrets.DT_TENANT }}
+      DT_ENVIRONMENT: ${{ secrets.DT_ENVIRONMENT }}
       DT_OPERATOR_TOKEN: ${{ secrets.DT_OPERATOR_TOKEN }}
       DT_INGEST_TOKEN: ${{ secrets.DT_INGEST_TOKEN }}
     steps:
@@ -30,7 +30,7 @@ jobs:
         run: |
             cd .devcontainer 
             cat <<EOF >> runlocal/.env
-            DT_TENANT=$DT_TENANT
+            DT_ENVIRONMENT=$DT_ENVIRONMENT
             DT_OPERATOR_TOKEN=$DT_OPERATOR_TOKEN
             DT_INGEST_TOKEN=$DT_INGEST_TOKEN
             EOF

--- a/.gitignore
+++ b/.gitignore
@@ -167,8 +167,12 @@ site/*
 
 # no env files
 .devcontainer/util/.env*
+.devcontainer/util/.count*
 .devcontainer/.env*
 .devcontainer/runlocal/.env*
+
+#no count
+.devcontainer/util/.count*
 
 # no logs
 logs

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,11 @@
+{
+	"servers": {
+		"dynatrace-mcp-server": {
+			"type": "stdio",
+			"command": "npx",
+			"cwd": "${workspaceFolder}",
+			"args": ["-y","@dynatrace-oss/dynatrace-mcp-server@latest"],
+			"envFile": "${workspaceFolder}/.devcontainer/runlocal/.env"
+		}
+	}
+}

--- a/docs/4-deploy-dynatrace.md
+++ b/docs/4-deploy-dynatrace.md
@@ -52,7 +52,7 @@ The automation script will utilize environment variables for deploying Dynatrace
 From your terminal, set the environment variables with the `export` command.
 
 ```sh
-export DT_TENANT=https://abc123.live.dynatrace.com
+export DT_ENVIRONMENT=https://abc123.apps.dynatrace.com
 export DT_OPERATOR_TOKEN=dt0c01.<YOUR-DYNATRACE-OPERATOR-TOKEN>
 export DT_INGEST_TOKEN=dt0c01.<YOUR-DATA-INGEST-TOKEN>
 ```

--- a/docs/snippets/dt-enablement.md
+++ b/docs/snippets/dt-enablement.md
@@ -4,5 +4,7 @@
     - Seamless operation within GitHub Codespaces, as a remote container, or locally via Docker.
     - Cross-compilation support for both AMD and ARM architectures, ensuring broad compatibility.
     - Adherence to industry standards and best practices to optimize the developer experience.
+    - Real-time observability of Kubernetes clusters using [Dynatrace Full-Stack monitoring](https://dynatrace-wwse.github.io/codespaces-framework/dynatrace-integration/).
+    - Integrated [Dynatrace MCP Server](https://dynatrace-wwse.github.io/codespaces-framework/dynatrace-integration/) to deliver deep, actionable insights across distributed systems.
 
-    To learn more about the Dynatrace Enablement Framework and how it can enhance your development workflow, please refer to the [official documentation](https://dynatrace-wwse.github.io/codespaces-framework)
+    To learn more about the Dynatrace Enablement Framework and how it can enhance your development workflow, please refer to the [official documentation](https://dynatrace-wwse.github.io/codespaces-framework)      


### PR DESCRIPTION
Adding Dynatrace MCP Server config
- mcp.json server configuration
- setUpMCPServer function to setup variables
- DT_TENANT stays for classic usage but DT_ENVIRONMENT is what the enduser sets up as platform URL. No Live but apps. 3rd gen notation
- refactor of variables
- checkHost function enhanced for having npm and node (for setting up the HOST or container)
- Dockerimage and tag is bumped and crosscompiled for ARM/AMD for supporting the MCP Server as VS Code extension
- dt-enablement.md snipped updated to show changes of MCP Server functionality
