### PR TITLE
Dev Container image v1.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Dynatrace Enablement Container",
   // Pulling the image from the Dockerhub, runs on AMD64 and ARM64. Pulling is normally faster.
-  "image":"shinojosa/dt-enablement:v1.1",
+  "image":"shinojosa/dt-enablement:v1.2",
   /*
   // Building the image from the Dockerfile
   "build": {

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -23,7 +23,7 @@ theme:
   palette:
   # Palette toggle for automatic mode
   - media: "(prefers-color-scheme)"
-    primary: deep-purple
+    primary: blue
     toggle:
       icon: material/brightness-auto
       name: Switch to light mode
@@ -31,7 +31,7 @@ theme:
   # Palette toggle for light mode
   - media: "(prefers-color-scheme: light)"
     scheme: default 
-    primary: deep-purple
+    primary: blue
     toggle:
       icon: material/brightness-7
       name: Switch to dark mode
@@ -39,7 +39,7 @@ theme:
   # Palette toggle for dark mode
   - media: "(prefers-color-scheme: dark)"
     scheme: slate
-    primary: deep-purple
+    primary: blue
     toggle:
       icon: material/brightness-4
       name: Switch to system preference


### PR DESCRIPTION

- devcontainer.json -> image shinojosa/dt-enablement:v1.2
    - Node (NPX) built in the image for MCP Server 
