### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,5 +1,4 @@
 # Getting Started
---8<-- "snippets/send-bizevent/2-getting-started.js"
 
 --8<-- "snippets/requirements.md"
 

--- a/docs/3-codespaces.md
+++ b/docs/3-codespaces.md
@@ -1,5 +1,4 @@
 # Codespaces
---8<-- "snippets/send-bizevent/3-codespaces.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/4-deploy-dynatrace.md
+++ b/docs/4-deploy-dynatrace.md
@@ -1,5 +1,4 @@
 # Deploy Dynatrace
---8<-- "snippets/send-bizevent/4-deploy-dynatrace.js"
 
 !!! tip "Deploy Dynatrace Approach"
     This guide offers (2) approaches to deploying Dynatrace for this workshop.  To speed things up and get log data into Dynatrace as quickly as possible, the automated (scripted) approach will deploy Dynatrace for you using helper functions.  To learn the process of deploying Dynatrace on Kubernetes and to customize the deployment to your needs, you can follow the manual (guided) approach.

--- a/docs/5-scaling-log-analytics.md
+++ b/docs/5-scaling-log-analytics.md
@@ -1,5 +1,4 @@
 # Scaling Log Analytics
---8<-- "snippets/send-bizevent/5-scaling-log-analytics.js"
 
 Let’s be real — logs are your lifeline. Whether you're chasing down a production bug at 2 a.m. or trying to understand why latency just spiked, you need answers fast. That’s where Dynatrace comes in. It scales log analytics effortlessly, ingesting massive volumes without breaking a sweat, and delivers lightning-fast search and AI-powered context so you can go from “what just happened?” to “problem solved” in minutes. No more stitching together tools or waiting on queries — just instant clarity, full-stack visibility, and the kind of speed that makes you feel like a superhero.
 

--- a/docs/6-configure-dynatrace.md
+++ b/docs/6-configure-dynatrace.md
@@ -1,5 +1,4 @@
 # Configure Dynatrace
---8<-- "snippets/send-bizevent/6-configure-dynatrace.js"
 
 In this workshop module, we'll configure the Dynatrace tenant based on the best practices covered in scaling log analytics.
 

--- a/docs/7-dql-exercises.md
+++ b/docs/7-dql-exercises.md
@@ -1,5 +1,4 @@
 # DQL Exercises
---8<-- "snippets/send-bizevent/7-dql-exercises.js"
 
 Now that logs are flowing into Dynatrace from our Kubernetes environment, it's time to unlock their full potential. Enter Dynatrace Query Language (DQL) - a powerful, intuitive language purpose-built for observability at scale. With DQL, you can slice through massive volumes of log data with precision, filter by meaningful attributes, extract insights in seconds, and even correlate logs with traces and metrics—all in a single query. Whether you're troubleshooting an issue, hunting for anomalies, or building dashboards, DQL makes it easy to ask complex questions and get clear answers fast. Let’s dive in and see how DQL transforms raw log data into actionable intelligence.
 

--- a/docs/8-anomaly-detection.md
+++ b/docs/8-anomaly-detection.md
@@ -1,5 +1,4 @@
 # Anomaly Detection
---8<-- "snippets/send-bizevent/8-anomaly-detection.js"
 
 Now that we know how to perform powerful queries on our log data, let's explore how Dynatrace detects anomalies by analyzing raw log records and converting them into metrics using OpenPipeline. Dynatrace enhances observability by transforming log data into time-series metrics, enabling anomaly detection through static thresholds, auto-adaptive baselines, and seasonal baselines. Static thresholds provide fixed limits for alerting, while auto-adaptive baselines learn and adjust to dynamic system behavior, and seasonal baselines account for recurring patterns such as daily or weekly cycles. This approach allows for proactive identification of performance issues and unusual behavior across your environment.
 

--- a/docs/9-dashboards.md
+++ b/docs/9-dashboards.md
@@ -1,5 +1,4 @@
 # Dashboards
---8<-- "snippets/send-bizevent/9-dashboards.js"
 
 In this section of the workshop, you'll use Dynatrace log analytics and dashboards to visualize key aspects of your environment, including business outcomes, application resiliency, and infrastructure health — derived from log data in context. By querying and aggregating logs, you can uncover insights into user behavior, transaction success rates, error patterns, and system performance. Dynatrace dashboards allow you to present these insights in a clear, contextualized format, enabling teams to monitor service reliability, detect emerging issues, and correlate technical signals with business impact in real time.
 

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,5 +1,4 @@
 # Cleanup
---8<-- "snippets/send-bizevent/cleanup.js"
 
 --8<-- "snippets/feedback.md"
 

--- a/docs/content-placeholder.md
+++ b/docs/content-placeholder.md
@@ -1,7 +1,6 @@
 <!--TODO: Update Lab Task -->
 # Lab Task
 <!--TODO: Update bizevent code snippet -->
---8<-- "snippets/send-bizevent/4-content-placeholder.js"
 
 <!--TODO: Update Lab task and learn more link -->
 Lab task description and primer

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 # About
---8<-- "snippets/send-bizevent/index.js"
 
 --8<-- "snippets/disclaimer.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,5 +1,4 @@
 # Resources
---8<-- "snippets/send-bizevent/resources.js"
 
 ### Dynatrace Query Language
 

--- a/docs/snippets/send-bizevent/2-getting-started.js
+++ b/docs/snippets/send-bizevent/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/3-codespaces.js
+++ b/docs/snippets/send-bizevent/3-codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"})
-});
-</script>

--- a/docs/snippets/send-bizevent/4-deploy-dynatrace.js
+++ b/docs/snippets/send-bizevent/4-deploy-dynatrace.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Deploy Dynatrace"})
-});
-</script>

--- a/docs/snippets/send-bizevent/5-scaling-log-analytics.js
+++ b/docs/snippets/send-bizevent/5-scaling-log-analytics.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Scaling Log Analytics"})
-});
-</script>

--- a/docs/snippets/send-bizevent/6-configure-dynatrace.js
+++ b/docs/snippets/send-bizevent/6-configure-dynatrace.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Configure Dynatrace"})
-});
-</script>

--- a/docs/snippets/send-bizevent/7-dql-exercises.js
+++ b/docs/snippets/send-bizevent/7-dql-exercises.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. DQL Exercises"})
-});
-</script>

--- a/docs/snippets/send-bizevent/8-anomaly-detection.js
+++ b/docs/snippets/send-bizevent/8-anomaly-detection.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "8. Anomaly Detection"})
-});
-</script>

--- a/docs/snippets/send-bizevent/9-dashboards.js
+++ b/docs/snippets/send-bizevent/9-dashboards.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "9. Dashboards"})
-});
-</script>

--- a/docs/snippets/send-bizevent/cleanup.js
+++ b/docs/snippets/send-bizevent/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Cleanup"})
-});
-</script>

--- a/docs/snippets/send-bizevent/index.js
+++ b/docs/snippets/send-bizevent/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"})
-});
-</script>

--- a/docs/snippets/send-bizevent/resources.js
+++ b/docs/snippets/send-bizevent/resources.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "Resources"})
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)