### PR TITLE
chore: sync framework @ 1.9.5

### DIFF
--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.8.3}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.9.5}"
 
 # Derive REPO_PATH from this script's own location (repo/.devcontainer/util/...),
 # NOT from $(pwd): shells opened outside the repo dir (docker exec lands in "/")


### PR DESCRIPTION
## Sync update

- Bumps `FRAMEWORK_VERSION` from `1.8.3` to `1.9.5`.
- Updates templates (`source_framework.sh`, `Makefile`).
- Removes framework-owned files (Category A) — now pulled from cache.

Auto-generated by `sync push-update`.